### PR TITLE
groper(dig) -t option option default using ```A```

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -87,6 +87,7 @@ switch(command) {
             timeout = flags.o || flags.timeout,
             options = {};
 
+        if(!type) { type = 'A'; }
         if(address) options.server = { address: address };
         if(port) options.server = { port: port };
         if(timeout) options.timeout = timeout;


### PR DESCRIPTION
The default value of the -t option of groper in A record

``` sh
# this command is same below
domain groper example.com
   NAME    |  TYPE  | CLASS  |  TTL   |   ADDRESS
example.com|   1    |   1    |  4829  |93.184.216.34

domain groper example.com -t A
   NAME    |  TYPE  | CLASS  |  TTL   |   ADDRESS
example.com|   1    |   1    | 16517  |93.184.216.34
```
